### PR TITLE
Fix issue with files removed although they are needed downstream.

### DIFF
--- a/src/main/groovy/nextflow/boost/cleanup/CleanupObserver.groovy
+++ b/src/main/groovy/nextflow/boost/cleanup/CleanupObserver.groovy
@@ -237,13 +237,18 @@ class CleanupObserver implements TraceObserver {
         log.trace "Processing ${events.size()} workflow events"
 
         // process each event
+        // we first need to proces the task completed events to
+        // make sure all output paths are in the paths object and
+        // can then be modified by onTaskComplete0.
         boolean cleanup = false
+        for( final event : events ) {
+            if( event instanceof Event.TaskCompleted ) {
+                cleanup |= onTaskComplete0(event.task)
+            }
+        }
         for( final event : events ) {
             if( event instanceof Event.TaskPending ) {
                 onTaskPending0(event.task)
-            }
-            else if( event instanceof Event.TaskCompleted ) {
-                cleanup |= onTaskComplete0(event.task)
             }
             else if( event instanceof Event.FilePublished ) {
                 onFilePublish0(event.path)


### PR DESCRIPTION
Hi @bentsherman, I finally took the time to look at the issue I'd opened here and resolved it in this PR. I tested it on my minimal example of the bug and it fixed the issue. From what I can tell, you don't have tests in the plugin, so I also did not write any tests for the fix. As a disclaimer I don't really know groovy, but as the issue was in the logic, and the fix straightforward,I think the fix should be ok. Of course, as you'll see, the fix is a bit of a quick fix, still relying on all the necessary events being there when we handle the queue, which might not be the case under certain circumstances (you could have the `TaskPending` that have already been emitted but not the `TaskCompleted` event), and I did not dig enough into the nextflow code to be sure that this case would never happen, but generally I expect it to be very unlikely. More info on the bug and the fix below...

There was an issue in the clean-up logic, leading to files needed by pending tasks not getting marked as such so that they would get deleted. The implementation relied on a precise event order (task completion event before new task creation events), which is not the actual order of events in nextflow (new task creation happens before parent task completion). 

To be more precise, files do not get marked as needed by downstream tasks if they are not in the `paths` object when the `TaskPending` events get handled (see https://github.com/bentsherman/nf-boost/blob/main/src/main/groovy/nextflow/boost/cleanup/CleanupObserver.groovy#L279), and as the files get added to `paths` in the `TaskCompleted` event (https://github.com/bentsherman/nf-boost/blob/main/src/main/groovy/nextflow/boost/cleanup/CleanupObserver.groovy#L333), this would basically lead to no files getting marked as necessary for downstream tasks as the `TaskPending` events always come before the `TaskCompleted` event of the parent task (see implementation of nextflow, where output files get added to output channels, triggering creation of downstream tasks before the parent task gets finalized).

resolves https://github.com/bentsherman/nf-boost/issues/4